### PR TITLE
Add getViewImpl() to MultiChoiceSimpleCursorAdapter

### DIFF
--- a/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceSimpleCursorAdapter.java
+++ b/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceSimpleCursorAdapter.java
@@ -105,4 +105,8 @@ public abstract class MultiChoiceSimpleCursorAdapter extends SimpleCursorAdapter
         View viewWithoutSelection = super.getView(position, convertView, parent);
         return helper.getView(position, viewWithoutSelection);
     }
+    
+    protected View getViewImpl(int position, View convertView, ViewGroup parent) {
+        return super.getView(position, convertView, parent);
+    }
 }


### PR DESCRIPTION
Correlates to what MultiChoiceArrayAdapter has in its wiki. 'To apply it, override getViewImpl() in your adapter class like this:'
