### PR TITLE
Fix crash when first loading AlphabetIndexer sample

### DIFF
--- a/sample/src/com/manuelpeinado/multichoiceadapter/demo/alphabetindexersample/AlphabetIndexerActivity.java
+++ b/sample/src/com/manuelpeinado/multichoiceadapter/demo/alphabetindexersample/AlphabetIndexerActivity.java
@@ -103,15 +103,16 @@ public class AlphabetIndexerActivity extends SherlockFragmentActivity
             prefs.edit().putBoolean("dbInitialized", true).commit();
             rebuildList();
         }
-        if (adapter == null) {
-            adapter = new AlphabetIndexerCursorAdapter(savedInstanceState, this, cursor);
-            adapter.setOnItemClickListener(this);
-            ListView listView = getListView();
-            listView.setFastScrollEnabled(true);
-            adapter.setAdapterView(listView);
-        }
-        else {
-            adapter.changeCursor(cursor);
+        if (cursor.getCount() > 0) {
+            if (adapter == null) {
+                adapter = new AlphabetIndexerCursorAdapter(savedInstanceState, this, cursor);
+                adapter.setOnItemClickListener(this);
+                ListView listView = getListView();
+                getListView().setFastScrollEnabled(true);
+                adapter.setAdapterView(listView);
+            } else {
+                adapter.changeCursor(cursor);
+            }
         }
     }
     


### PR DESCRIPTION
On Google Edition HTC One, the AlphabetIndexer sample crashes the first time it is opened:

```
    E  android.database.CursorIndexOutOfBoundsException: Index 0 requested, with a size of 0
                    E   at android.database.AbstractCursor.checkPosition(AbstractCursor.java:430)
                    E   at android.database.AbstractWindowedCursor.checkPosition(AbstractWindowedCursor.java:136)
                    E   at android.database.AbstractWindowedCursor.getString(AbstractWindowedCursor.java:50)
                    E   at android.database.CursorWrapper.getString(CursorWrapper.java:118)
                    E   at android.widget.AlphabetIndexer.getSectionForPosition(AlphabetIndexer.java:258)
                    E   at com.manuelpeinado.multichoiceadapter.demo.alphabetindexersample.AlphabetIndexerCursorAdapter.getSectionForPosition(AlphabetIndexerCursorAdapter.j
                       ava:93)
                    E   at android.widget.FastScroller.getThumbPositionForListPosition(FastScroller.java:647)
                    E   at android.widget.FastScroller.onScroll(FastScroller.java:457)
                    E   at android.widget.AbsListView.invokeOnItemScrollListener(AbsListView.java:1452)
                    [.....]
```

Not sure this is the best way to fix it but it did stop the crash.
