### PR TITLE
Added option to change ActionMode title

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.6.+'
+        classpath 'com.android.tools.build:gradle:0.8.+'
     }
 }
 

--- a/extras/actionbarcompat/src/com/manuelpeinado/multichoiceadapter/extras/actionbarcompat/MultiChoiceArrayAdapter.java
+++ b/extras/actionbarcompat/src/com/manuelpeinado/multichoiceadapter/extras/actionbarcompat/MultiChoiceArrayAdapter.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v7.view.ActionMode;
 import android.view.View;
@@ -125,5 +126,11 @@ public abstract class MultiChoiceArrayAdapter<T> extends ArrayAdapter<T> impleme
     @Override
     public boolean isItemCheckable(int position) {
         return true;
+    }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
     }
 }

--- a/extras/actionbarcompat/src/com/manuelpeinado/multichoiceadapter/extras/actionbarcompat/MultiChoiceBaseAdapter.java
+++ b/extras/actionbarcompat/src/com/manuelpeinado/multichoiceadapter/extras/actionbarcompat/MultiChoiceBaseAdapter.java
@@ -18,6 +18,7 @@ package com.manuelpeinado.multichoiceadapter.extras.actionbarcompat;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v7.view.ActionMode;
 import android.view.View;
@@ -215,6 +216,12 @@ public abstract class MultiChoiceBaseAdapter extends BaseAdapter implements Acti
     @Override
     public boolean isItemCheckable(int position) {
         return true;
+    }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
     }
 
     //

--- a/extras/actionbarcompat/src/com/manuelpeinado/multichoiceadapter/extras/actionbarcompat/MultiChoiceSimpleCursorAdapter.java
+++ b/extras/actionbarcompat/src/com/manuelpeinado/multichoiceadapter/extras/actionbarcompat/MultiChoiceSimpleCursorAdapter.java
@@ -18,6 +18,7 @@ package com.manuelpeinado.multichoiceadapter.extras.actionbarcompat;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.support.v4.widget.SimpleCursorAdapter;
@@ -112,6 +113,13 @@ public abstract class MultiChoiceSimpleCursorAdapter extends SimpleCursorAdapter
     public boolean isItemCheckable(int position) {
         return true;
     }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
+    }
+
 
     /**
      * Override this method if you need to customize the model-to-view mapping performed by SimpleCursorAdapter (for

--- a/extras/actionbarsherlock/src/com/manuelpeinado/multichoiceadapter/extras/actionbarsherlock/MultiChoiceAdapterHelper.java
+++ b/extras/actionbarsherlock/src/com/manuelpeinado/multichoiceadapter/extras/actionbarsherlock/MultiChoiceAdapterHelper.java
@@ -18,6 +18,7 @@ package com.manuelpeinado.multichoiceadapter.extras.actionbarsherlock;
 import android.widget.BaseAdapter;
 
 import com.actionbarsherlock.app.SherlockActivity;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.actionbarsherlock.view.ActionMode;
 import com.manuelpeinado.multichoiceadapter.MultiChoiceAdapterHelperBase;
 
@@ -30,14 +31,19 @@ public class MultiChoiceAdapterHelper extends MultiChoiceAdapterHelperBase {
 
     @Override
     protected void startActionMode() {
-        if (!(adapterView.getContext() instanceof SherlockActivity)) {
-            throw new IllegalStateException("List view must belong to a SherlockActivity");
-        }
         if (!(owner instanceof ActionMode.Callback)) {
             throw new IllegalStateException("Owner adapter must implement ActionMode.Callback");
         }
-        SherlockActivity activity = (SherlockActivity) adapterView.getContext();
-        actionMode = activity.startActionMode((ActionMode.Callback)owner); 
+        if (adapterView.getContext() instanceof SherlockActivity) {
+            SherlockActivity activity = (SherlockActivity) adapterView.getContext();
+            actionMode = activity.startActionMode((ActionMode.Callback)owner);
+        } else if (adapterView.getContext() instanceof SherlockFragmentActivity) {
+            SherlockFragmentActivity activity = (SherlockFragmentActivity) adapterView.getContext();
+            actionMode = activity.startActionMode((ActionMode.Callback)owner);
+        } else {
+            throw new IllegalStateException("List view must belong to a SherlockActivity or SherlockFragmentActivity");
+        }
+
     }
 
     @Override

--- a/extras/actionbarsherlock/src/com/manuelpeinado/multichoiceadapter/extras/actionbarsherlock/MultiChoiceArrayAdapter.java
+++ b/extras/actionbarsherlock/src/com/manuelpeinado/multichoiceadapter/extras/actionbarsherlock/MultiChoiceArrayAdapter.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
@@ -125,5 +126,11 @@ public abstract class MultiChoiceArrayAdapter<T> extends ArrayAdapter<T> impleme
     @Override
     public boolean isItemCheckable(int position) {
         return true;
+    }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
     }
 }

--- a/extras/actionbarsherlock/src/com/manuelpeinado/multichoiceadapter/extras/actionbarsherlock/MultiChoiceBaseAdapter.java
+++ b/extras/actionbarsherlock/src/com/manuelpeinado/multichoiceadapter/extras/actionbarsherlock/MultiChoiceBaseAdapter.java
@@ -18,6 +18,7 @@ package com.manuelpeinado.multichoiceadapter.extras.actionbarsherlock;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
@@ -215,6 +216,12 @@ public abstract class MultiChoiceBaseAdapter extends BaseAdapter implements Acti
     @Override
     public boolean isItemCheckable(int position) {
         return true;
+    }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
     }
 
     //

--- a/extras/actionbarsherlock/src/com/manuelpeinado/multichoiceadapter/extras/actionbarsherlock/MultiChoiceSimpleCursorAdapter.java
+++ b/extras/actionbarsherlock/src/com/manuelpeinado/multichoiceadapter/extras/actionbarsherlock/MultiChoiceSimpleCursorAdapter.java
@@ -18,6 +18,7 @@ package com.manuelpeinado.multichoiceadapter.extras.actionbarsherlock;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.support.v4.widget.SimpleCursorAdapter;
@@ -112,6 +113,13 @@ public abstract class MultiChoiceSimpleCursorAdapter extends SimpleCursorAdapter
     public boolean isItemCheckable(int position) {
         return true;
     }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
+    }
+
 
     /**
      * Override this method if you need to customize the model-to-view mapping performed by SimpleCursorAdapter (for

--- a/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceAdapter.java
+++ b/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceAdapter.java
@@ -33,4 +33,5 @@ public interface MultiChoiceAdapter {
     void setItemClickInActionModePolicy(ItemClickInActionModePolicy policy);
     ItemClickInActionModePolicy getItemClickInActionModePolicy();
     boolean isItemCheckable(int position);
+    String getActionModeTitle(int count);
 }

--- a/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceAdapterHelperBase.java
+++ b/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceAdapterHelperBase.java
@@ -166,9 +166,8 @@ public abstract class MultiChoiceAdapterHelperBase implements OnItemLongClickLis
             finishActionMode();
             return;
         }
-        Resources res = adapterView.getResources();
-        String title = res.getQuantityString(R.plurals.selected_items, count, count);
-        setActionModeTitle(title);
+        MultiChoiceAdapter adapter = (MultiChoiceAdapter) owner;
+        setActionModeTitle(adapter.getActionModeTitle(count));
     }
 
     protected abstract void setActionModeTitle(String title);

--- a/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceArrayAdapter.java
+++ b/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceArrayAdapter.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.ActionMode;
 import android.view.View;
@@ -122,5 +123,11 @@ public abstract class MultiChoiceArrayAdapter<T> extends ArrayAdapter<T> impleme
     @Override
     public boolean isItemCheckable(int position) {
         return true;
+    }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
     }
 }

--- a/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceBaseAdapter.java
+++ b/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceBaseAdapter.java
@@ -18,6 +18,7 @@ package com.manuelpeinado.multichoiceadapter;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.ActionMode;
 import android.view.View;
@@ -212,6 +213,12 @@ public abstract class MultiChoiceBaseAdapter extends BaseAdapter implements Acti
     @Override
     public boolean isItemCheckable(int position) {
         return true;
+    }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
     }
 
     //

--- a/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceSimpleCursorAdapter.java
+++ b/library/src/com/manuelpeinado/multichoiceadapter/MultiChoiceSimpleCursorAdapter.java
@@ -18,6 +18,7 @@ package com.manuelpeinado.multichoiceadapter;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.view.ActionMode;
@@ -108,6 +109,12 @@ public abstract class MultiChoiceSimpleCursorAdapter extends SimpleCursorAdapter
     @Override
     public boolean isItemCheckable(int position) {
         return true;
+    }
+
+    @Override
+    public String getActionModeTitle(int count) {
+        Resources res = getContext().getResources();
+        return res.getQuantityString(R.plurals.selected_items, count, count);
     }
 
     /**

--- a/samples/actionbarcompat/AndroidManifest.xml
+++ b/samples/actionbarcompat/AndroidManifest.xml
@@ -23,7 +23,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="cocom.manuelpeinado.multichoiceadapter.samples.actionbarcompat.baseadaptersample.BaseAdapterActivity"
+            android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarcompat.baseadaptersample.BaseAdapterActivity"
             android:label="@string/activity_title_base_adapter" />
         <activity
             android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarcompat.arrayadaptersample.ArrayAdapterActivity"
@@ -41,16 +41,16 @@
             android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarcompat.gallerysample.GalleryActivity"
             android:label="@string/activity_title_gallery" />
         <activity
-            android:name="com.manucom.manuelpeinado.multichoiceadapter.samples.actionbarcompat.headersample.HeaderActivity"
+            android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarcompat.headersample.HeaderActivity"
             android:label="@string/activity_title_header" />
         <activity
-            android:name="com.manuelcom.manuelpeinado.multichoiceadapter.samples.actionbarcompat.manyitemssample.ManyItemsActivity"
+            android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarcompat.manyitemssample.ManyItemsActivity"
             android:label="@string/activity_title_many_items" />
         <activity
             android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarcompat.complexitemlayoutsample.ComplexItemLayoutActivity"
             android:label="@string/activity_title_complex_item_layout" />
         <activity
-            android:name="com.manuelpeinado.multichoiceadapter.demo.alphabetindexersample.AlphabetIndexerActivity"
+            android:name="com.manuelpeinado.multichoiceadapter.samples.alphabetindexersample.AlphabetIndexerActivity"
             android:label="@string/activity_title_alphabet_indexer" />
         <activity
             android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarcompat.noncheckableitemssample.NonCheckableItemsActivity"

--- a/samples/actionbarcompat/build.gradle
+++ b/samples/actionbarcompat/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'android'
 
 dependencies {
-    compile project(':extras/actionbarsherlock')
+    compile project(':extras/actionbarcompat')
 }
 
 android {

--- a/samples/actionbarsherlock/AndroidManifest.xml
+++ b/samples/actionbarsherlock/AndroidManifest.xml
@@ -50,7 +50,7 @@
             android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarsherlock.complexitemlayoutsample.ComplexItemLayoutActivity"
             android:label="@string/activity_title_complex_item_layout" />
         <activity
-            android:name="com.manuelpeinado.multichoiceadapter.demo.alphabetindexersample.AlphabetIndexerActivity"
+            android:name="com.manuelpeinado.multichoiceadapter.samples.alphabetindexersample.AlphabetIndexerActivity"
             android:label="@string/activity_title_alphabet_indexer" />
         <activity
             android:name="com.manuelpeinado.multichoiceadapter.samples.actionbarsherlock.noncheckableitemssample.NonCheckableItemsActivity"

--- a/samples/stock/build.gradle
+++ b/samples/stock/build.gradle
@@ -1,9 +1,5 @@
 apply plugin: 'android'
 
-dependencies {
-    compile project(':library')
-}
-
 android {
     compileSdkVersion 19
     buildToolsVersion '19'
@@ -20,4 +16,8 @@ android {
             res.srcDirs = ['res']
         }
     }
+}
+
+dependencies {
+    compile project(':library')
 }


### PR DESCRIPTION
I have added a method to MultiChoiceAdapter interface that receive the count of selected items and returns the title for ActionMode. By default it returns Resources.getQuantityString(R.plurals.selected_items, count, count) but the user can extends this method in Adapter.

I have changed the plugin gradle version to compile successfully with Gradle 1.10

I changed the activity names in samples and I have fixed a bug in the class com.manuelpeinado.multichoiceadapter.extras.actionbarsherlock.MultiChoiceAdapterHelper

Hope this helps
